### PR TITLE
Support for RKE2

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,9 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
 
 	"gopkg.in/yaml.v3"
 )
@@ -201,7 +201,10 @@ func processUserData(configDriveDir string) error {
 		}
 		defer f.Close()
 
-		decodedContent, err := DecodeContent(file.Content, file.Encoding) 
+		decodedContent, err := DecodeContent(file.Content, file.Encoding)
+		if err != nil {
+			log.Printf("Error decoding permissions for file %s: %s", file.Path, err)
+		}
 		n, err := f.Write(decodedContent)
 		if err != nil {
 			log.Printf("Error writing file %s: %s", file.Path, err)
@@ -210,7 +213,7 @@ func processUserData(configDriveDir string) error {
 		}
 	}
 
-    // Run commands
+	// Run commands
 	for _, cmd := range cc.RunCmd {
 		cmdArgs := strings.Fields(cmd)
 		output, err := exec.Command(cmdArgs[0], cmdArgs[1:]...).CombinedOutput()
@@ -357,17 +360,18 @@ func (f *CloudConfigFile) OSPermissions() (os.FileMode, error) {
 	// Parse string representation of file mode as integer
 	perm, err := strconv.ParseInt(f.Permissions, 8, 32)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to parse file permissions %q as integer", f.Permissions)
+		return 0, fmt.Errorf("unable to parse file permissions %q as integer", f.Permissions)
 	}
 	return os.FileMode(perm), nil
 }
 
 // Decoding functions
+// copied from github.com/flatcar-linux/coreos-cloudinit
 func DecodeBase64Content(content string) ([]byte, error) {
 	output, err := base64.StdEncoding.DecodeString(content)
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to decode base64: %q", err)
+		return nil, fmt.Errorf("unable to decode base64: %q", err)
 	}
 
 	return output, nil
@@ -377,7 +381,7 @@ func DecodeGzipContent(content string) ([]byte, error) {
 	gzr, err := gzip.NewReader(bytes.NewReader([]byte(content)))
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to decode gzip: %q", err)
+		return nil, fmt.Errorf("unable to decode gzip: %q", err)
 	}
 	defer gzr.Close()
 
@@ -408,5 +412,5 @@ func DecodeContent(content string, encoding string) ([]byte, error) {
 		return DecodeGzipContent(string(gz))
 	}
 
-	return nil, fmt.Errorf("Unsupported encoding %q", encoding)
+	return nil, fmt.Errorf("unsupported encoding %q", encoding)
 }

--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
-	"path/filepath"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -190,8 +191,8 @@ func processUserData(configDriveDir string) error {
 
 	//write files
 	for _, file := range cc.WriteFiles {
-        // Replace "/usr/local" with "/opt" in Path, since Flatcar has read-only /usr
-        file.Path = strings.Replace(file.Path, "/usr/local", "/opt", -1)
+		// Replace "/usr/local" with "/opt" in Path, since Flatcar has read-only /usr
+		file.Path = strings.Replace(file.Path, "/usr/local", "/opt", -1)
 
 		// Create directory if it does not exist
 		dir := filepath.Dir(file.Path)
@@ -204,7 +205,7 @@ func processUserData(configDriveDir string) error {
 		if err != nil {
 			log.Printf("Invalid file permissions for %s: %s", file.Path, file.Permissions)
 		}
-    
+
 		f, err := os.OpenFile(file.Path, os.O_CREATE|os.O_WRONLY, perm)
 		if err != nil {
 			log.Printf("Error creating file: %s", err)
@@ -225,8 +226,7 @@ func processUserData(configDriveDir string) error {
 
 	// Run commands
 	for _, cmd := range cc.RunCmd {
-		cmdArgs := strings.Fields(cmd)
-		cmdArgs[0] = strings.Replace(cmdArgs[0], "/usr/local/custom_script", "/opt/custom_script", -1)
+		cmdArgs := strings.Fields(strings.Replace(cmd, "/usr/local/custom_script", "/opt/custom_script", -1))
 		output, err := exec.Command(cmdArgs[0], cmdArgs[1:]...).CombinedOutput()
 		if err != nil {
 			log.Printf("Error running command '%s': %s\n%s", cmd, err, output)

--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ func processUserData(configDriveDir string) error {
 		if err != nil {
 			log.Printf("Error writing file %s: %s", file.Path, err)
 		} else {
-			log.Printf("Wrote file %s successfully with %d lines.", file.Path, n)
+			log.Printf("Wrote file %s successfully with %d bytes.", file.Path, n)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-
+	"path/filepath"
 	"gopkg.in/yaml.v3"
 )
 
@@ -190,11 +190,21 @@ func processUserData(configDriveDir string) error {
 
 	//write files
 	for _, file := range cc.WriteFiles {
+        // Replace "/usr/local" with "/opt" in Path, since Flatcar has read-only /usr
+        file.Path = strings.Replace(file.Path, "/usr/local", "/opt", -1)
+
+		// Create directory if it does not exist
+		dir := filepath.Dir(file.Path)
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			log.Printf("Error creating directory %s: %s", dir, err)
+		}
+
 		perm, err := file.OSPermissions()
 		if err != nil {
 			log.Printf("Invalid file permissions for %s: %s", file.Path, file.Permissions)
 		}
-
+    
 		f, err := os.OpenFile(file.Path, os.O_CREATE|os.O_WRONLY, perm)
 		if err != nil {
 			log.Printf("Error creating file: %s", err)
@@ -216,6 +226,7 @@ func processUserData(configDriveDir string) error {
 	// Run commands
 	for _, cmd := range cc.RunCmd {
 		cmdArgs := strings.Fields(cmd)
+		cmdArgs[0] = strings.Replace(cmdArgs[0], "/usr/local/custom_script", "/opt/custom_script", -1)
 		output, err := exec.Command(cmdArgs[0], cmdArgs[1:]...).CombinedOutput()
 		if err != nil {
 			log.Printf("Error running command '%s': %s\n%s", cmd, err, output)

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -15,8 +16,9 @@ import (
 )
 
 type CloudConfig struct {
-	Groups []string          `yaml:"groups"`
-	Users  []CloudConfigUser `yaml:"users"`
+	Groups     []string          `yaml:"groups"`
+	Users      []CloudConfigUser `yaml:"users"`
+	WriteFiles []CloudConfigFile `yaml:"write_files"`
 }
 
 type CloudConfigUser struct {
@@ -35,6 +37,12 @@ type CloudConfigUser struct {
 	Shell             string   `yaml:"shell"`
 	System            bool     `yaml:"system"`
 	Sudo              string   `yaml:"sudo"`
+}
+
+type CloudConfigFile struct {
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions"`
+	Content     string `yaml:"content"`
 }
 
 type MetaData struct {
@@ -175,6 +183,27 @@ func processUserData(configDriveDir string) error {
 		}
 	}
 
+	//write files
+	for _, file := range cc.WriteFiles {
+		perm, err := file.OSPermissions()
+		if err != nil {
+			log.Printf("Invalid file permissions for %s: %s", file.Path, file.Permissions)
+		}
+
+		f, err := os.OpenFile(file.Path, os.O_CREATE|os.O_WRONLY, perm)
+		if err != nil {
+			log.Printf("Error creating file: %s", err)
+		}
+		defer f.Close()
+
+		n, err := f.WriteString(file.Content)
+		if err != nil {
+			log.Printf("Error writing file %s: %s", file.Path, err)
+		} else {
+			log.Printf("Wrote file %s successfully with %d lines.", file.Path, n)
+		}
+	}
+
 	return nil
 }
 
@@ -300,4 +329,18 @@ func userExists(u string) bool {
 func groupExists(g string) bool {
 	_, err := user.LookupGroup(g)
 	return err == nil
+}
+
+// Convert file permissions mode from String
+func (f *CloudConfigFile) OSPermissions() (os.FileMode, error) {
+	if f.Permissions == "" {
+		return os.FileMode(0644), nil
+	}
+
+	// Parse string representation of file mode as integer
+	perm, err := strconv.ParseInt(f.Permissions, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("Unable to parse file permissions %q as integer", f.Permissions)
+	}
+	return os.FileMode(perm), nil
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type CloudConfig struct {
 	Groups     []string          `yaml:"groups"`
 	Users      []CloudConfigUser `yaml:"users"`
 	WriteFiles []CloudConfigFile `yaml:"write_files"`
+	RunCmd     []string          `yaml:"runcmd"`
 }
 
 type CloudConfigUser struct {
@@ -206,6 +207,17 @@ func processUserData(configDriveDir string) error {
 			log.Printf("Error writing file %s: %s", file.Path, err)
 		} else {
 			log.Printf("Wrote file %s successfully with %d lines.", file.Path, n)
+		}
+	}
+
+    // Run commands
+	for _, cmd := range cc.RunCmd {
+		cmdArgs := strings.Fields(cmd)
+		output, err := exec.Command(cmdArgs[0], cmdArgs[1:]...).CombinedOutput()
+		if err != nil {
+			log.Printf("Error running command '%s': %s\n%s", cmd, err, output)
+		} else {
+			log.Printf("Ran command '%s' successfully.\n%s ", cmd, output)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,9 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 
 	"gopkg.in/yaml.v3"
 )
@@ -43,6 +46,7 @@ type CloudConfigFile struct {
 	Path        string `yaml:"path"`
 	Permissions string `yaml:"permissions"`
 	Content     string `yaml:"content"`
+	Encoding    string `yaml:"encoding"`
 }
 
 type MetaData struct {
@@ -196,7 +200,8 @@ func processUserData(configDriveDir string) error {
 		}
 		defer f.Close()
 
-		n, err := f.WriteString(file.Content)
+		decodedContent, err := DecodeContent(file.Content, file.Encoding) 
+		n, err := f.Write(decodedContent)
 		if err != nil {
 			log.Printf("Error writing file %s: %s", file.Path, err)
 		} else {
@@ -343,4 +348,53 @@ func (f *CloudConfigFile) OSPermissions() (os.FileMode, error) {
 		return 0, fmt.Errorf("Unable to parse file permissions %q as integer", f.Permissions)
 	}
 	return os.FileMode(perm), nil
+}
+
+// Decoding functions
+func DecodeBase64Content(content string) ([]byte, error) {
+	output, err := base64.StdEncoding.DecodeString(content)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to decode base64: %q", err)
+	}
+
+	return output, nil
+}
+
+func DecodeGzipContent(content string) ([]byte, error) {
+	gzr, err := gzip.NewReader(bytes.NewReader([]byte(content)))
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to decode gzip: %q", err)
+	}
+	defer gzr.Close()
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(gzr)
+
+	return buf.Bytes(), nil
+}
+
+func DecodeContent(content string, encoding string) ([]byte, error) {
+	switch encoding {
+	case "":
+		return []byte(content), nil
+
+	case "b64", "base64":
+		return DecodeBase64Content(content)
+
+	case "gz", "gzip":
+		return DecodeGzipContent(content)
+
+	case "gz+base64", "gzip+base64", "gz+b64", "gzip+b64":
+		gz, err := DecodeBase64Content(content)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return DecodeGzipContent(string(gz))
+	}
+
+	return nil, fmt.Errorf("Unsupported encoding %q", encoding)
 }

--- a/test/user-data
+++ b/test/user-data
@@ -11,3 +11,11 @@ users:
   - |
     ssh-rsa blahblahblah
   sudo: ALL=(ALL) NOPASSWD:ALL
+write_files:
+- content: H4sIAAAAAAAAA1JW1E/KzNNPSizO4EpNzshX8CxRCM8vyi5WBAAAAP//AwCxMIRMGgAAAA==
+  encoding: gzip+b64
+  path: /home/fabior/install.sh
+  permissions: "0644"
+runcmd:
+- "/usr/bin/echo It works!"
+- "/usr/bin/date"

--- a/test/user-data
+++ b/test/user-data
@@ -14,7 +14,7 @@ users:
 write_files:
 - content: H4sIAAAAAAAAA1JW1E/KzNNPSizO4EpNzshX8CxRCM8vyi5WBAAAAP//AwCxMIRMGgAAAA==
   encoding: gzip+b64
-  path: /home/fabior/install.sh
+  path: /home/docker/install.sh
   permissions: "0644"
 runcmd:
 - "/usr/bin/echo It works!"


### PR DESCRIPTION
When provisioning an RKE2 cluster, Rancher expects cloud-init to support `runcmd` and `write_files` directives. Coreos-cloudinit supports `write_files`, but not `runcmd`. This implements both directives to allow Rancher to provision RKE2 with Flatcar hosts.